### PR TITLE
Fix for all black "contentArea" on dark mode

### DIFF
--- a/popup/popup.css
+++ b/popup/popup.css
@@ -341,7 +341,7 @@ html, body {
 
 .contentArea {
   display: block;
-  position: absolute;
+  position: fixed;
   top: 36px;
   left: 36px;
   width: 564px;


### PR DESCRIPTION
Dark mode has had a bug since Firefox 60.0b3 (64-bit) where the contentArea shows as completely black unless something with a tooltip is currently moused over. It seems to be caused by adding a background color to "leftBar", which dark mode does, which in turn seems to cause a z-index bug.

The bug seems to only affect absolute and relative positions. Changing contentArea to position: fixed seems to have fixed the issue without causing any issues that I can see. Another method is to set leftBar to have an opacity of 0.989 or lower on dark mode, which doesn't change much visually due to the similar colour behind it on leftBarBack.